### PR TITLE
fix: Make server-side Stripe SDK init in lib/stripe.ts more resilient

### DIFF
--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -1,5 +1,5 @@
 import { loadStripe, StripeConstructorOptions } from "@stripe/stripe-js";
-import Stripe from "stripe";
+import StripeNode from "stripe"; // Renamed import
 
 const stripePublishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
 
@@ -9,9 +9,9 @@ console.log("NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:", stripePublishableKey ? "Exist
 let stripePromise;
 if (stripePublishableKey) {
   stripePromise = loadStripe(stripePublishableKey)
-    .then(stripe => {
+    .then(stripeInstance => { // Renamed variable here
       console.log("Stripe.js loaded successfully.");
-      return stripe;
+      return stripeInstance; // Renamed variable here
     })
     .catch(error => {
       console.error("Failed to load Stripe.js:", error);
@@ -22,13 +22,23 @@ if (stripePublishableKey) {
   stripePromise = Promise.resolve(null); // Resolve with null if key is missing
 }
 
-export { stripePromise };
-
-
 // Server-side Stripe
-export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: "2024-06-20",
-})
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+let stripe: StripeNode | null = null; // Use aliased import StripeNode
+
+if (stripeSecretKey) {
+  stripe = new StripeNode(stripeSecretKey, { // Use aliased import StripeNode
+    apiVersion: "2024-06-20",
+    typescript: true, // Added for good measure
+  });
+  console.log("Server-side Stripe SDK initialized.");
+} else {
+  console.error(
+    "STRIPE_SECRET_KEY is not set. Server-side Stripe SDK cannot be initialized. API routes requiring Stripe will fail."
+  );
+}
+
+export { stripePromise, stripe }; // Combined export for both client and server-side stripe objects
 
 export const STRIPE_PLANS = {
   "1-week": {


### PR DESCRIPTION
I've modified `lib/stripe.ts` to conditionally initialize the server-side Stripe SDK instance.

Here's what I changed:
- The server-side `stripe` object (now typed as `StripeNode | null`) is only instantiated if `process.env.STRIPE_SECRET_KEY` is present.
- If the key is missing, I'll log an error to the console, and the exported `stripe` instance will remain `null`.
- I renamed the Stripe import to `StripeNode` to avoid naming conflicts.
- I ensured `stripePromise` (client-side) and `stripe` (server-side) are both correctly exported.

This change prevents the module import from crashing if `STRIPE_SECRET_KEY` is not set. This could otherwise break client-side pages (like `app/checkout/page.tsx`) that import `stripePromise` from this file, even if they don't directly use the server-side instance.

API routes or other server-side code attempting to use the `stripe` object will still need to handle the case where it might be `null` if the environment variable is not properly configured. This change primarily improves the robustness of pages that might only depend on the client-side aspects of the Stripe integration.