### PR TITLE
Refactor: Separate client and server Stripe initialization

### DIFF
--- a/app/api/create-payment-intent/route.ts
+++ b/app/api/create-payment-intent/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { stripe, STRIPE_PLANS } from "@/lib/stripe"
+import { STRIPE_PLANS } from "@/lib/stripe"
+import { stripe } from "@/lib/stripe.server"
 
 export async function POST(request: NextRequest) {
   try {

--- a/lib/stripe.server.ts
+++ b/lib/stripe.server.ts
@@ -1,0 +1,20 @@
+import 'server-only';
+import StripeNode from "stripe"; // Renamed import
+
+// Server-side Stripe
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+let stripe: StripeNode | null = null; // Use aliased import StripeNode
+
+if (stripeSecretKey) {
+  stripe = new StripeNode(stripeSecretKey, { // Use aliased import StripeNode
+    apiVersion: "2024-06-20",
+    typescript: true, // Added for good measure
+  });
+  console.log("Server-side Stripe SDK initialized.");
+} else {
+  console.error(
+    "STRIPE_SECRET_KEY is not set. Server-side Stripe SDK cannot be initialized. API routes requiring Stripe will fail."
+  );
+}
+
+export { stripe }; // Export server-side stripe

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -1,5 +1,4 @@
 import { loadStripe, StripeConstructorOptions } from "@stripe/stripe-js";
-import StripeNode from "stripe"; // Renamed import
 
 const stripePublishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
 
@@ -22,23 +21,7 @@ if (stripePublishableKey) {
   stripePromise = Promise.resolve(null); // Resolve with null if key is missing
 }
 
-// Server-side Stripe
-const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
-let stripe: StripeNode | null = null; // Use aliased import StripeNode
-
-if (stripeSecretKey) {
-  stripe = new StripeNode(stripeSecretKey, { // Use aliased import StripeNode
-    apiVersion: "2024-06-20",
-    typescript: true, // Added for good measure
-  });
-  console.log("Server-side Stripe SDK initialized.");
-} else {
-  console.error(
-    "STRIPE_SECRET_KEY is not set. Server-side Stripe SDK cannot be initialized. API routes requiring Stripe will fail."
-  );
-}
-
-export { stripePromise, stripe }; // Combined export for both client and server-side stripe objects
+export { stripePromise }; // Export client-side stripe promise
 
 export const STRIPE_PLANS = {
   "1-week": {


### PR DESCRIPTION
Previously, the server-side Stripe SDK (using the secret key) was initialized in a file (`lib/stripe.ts`) that could be imported by client-side code. This caused an "Uncaught Error: Neither apiKey nor config.authenticator provided" in the browser console because the secret key is not available on the client.

This commit refactors the Stripe integration as follows:

1.  Server-side Stripe initialization (using `new Stripe(...)` with the secret key) has been moved to a new file: `lib/stripe.server.ts`.
2.  `lib/stripe.server.ts` is marked with `import 'server-only';` to ensure it is only bundled and executed on the server.
3.  The original `lib/stripe.ts` now only contains client-side Stripe logic (i.e., `loadStripe` using the publishable key via `stripePromise`) and shared constants like `STRIPE_PLANS`.
4.  Server-side API routes (e.g., `app/api/create-payment-intent/route.ts`) have been updated to import the server `stripe` instance from `lib/stripe.server.ts`.
5.  Client-side components continue to use `@stripe/react-stripe-js` hooks, which rely on the publishable key, and do not import server-only code.

This separation ensures that server-only Stripe code does not run in the browser, resolving the runtime error and enhancing security by keeping the secret key strictly on the server.