### PR TITLE
Integrate pricing on quiz page and update signup redirect

### DIFF
--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -27,6 +27,7 @@ import {
 import Link from "next/link"
 import Image from "next/image"
 import { useRouter } from "next/navigation"
+import { redirectToCheckout } from "@/lib/stripe-client";
 
 const quizQuestions = [
   // Demographics
@@ -1248,7 +1249,7 @@ export default function QuizPage() {
 
                       {/* CTA Button */}
                       <Button
-                        onClick={() => router.push(`/checkout?plan=${plan.id}&email=${email}`)}
+                        onClick={() => redirectToCheckout(plan.id)}
                         className={`w-full py-3 rounded-full font-semibold text-lg ${
                           plan.popular
                             ? "bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 text-white shadow-lg"

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -102,7 +102,7 @@ export function Header() {
                 Log In
               </Button>
             </Link>
-            <Link href="/checkout">
+            <Link href="/#pricing">
               <Button className="bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 text-white rounded-full px-6">
                 Get Started
               </Button>
@@ -146,7 +146,7 @@ export function Header() {
                     Log In
                   </Button>
                 </Link>
-                <Link href="/checkout">
+                <Link href="/#pricing">
                   <Button className="w-full bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 text-white rounded-full">
                     Get Started
                   </Button>


### PR DESCRIPTION
This commit implements two main features:
1. Displays pricing packages on the final quiz results page and links them to Stripe Checkout.
2. Modifies the main 'Get Started' CTA in the header to redirect you to the pricing section on the homepage.

Key changes:
- In `components/header.tsx`:
    - Changed the `href` for the 'Get Started' button (desktop and mobile) from `/checkout` to `/#pricing`.
- In `app/quiz/page.tsx`:
    - Imported `redirectToCheckout` from `@/lib/stripe-client`.
    - Modified the `onClick` handlers for the pricing plan buttons (displayed when quiz results are shown) to use `redirectToCheckout(plan.id)`, ensuring you are directed to Stripe for the selected plan. The existing UI for displaying plans on the quiz results page was leveraged.