### PR TITLE
fix: Update xAI model name for GlowBot chat

### DIFF
--- a/app/api/glowbot-chat/route.ts
+++ b/app/api/glowbot-chat/route.ts
@@ -75,7 +75,7 @@ export async function POST(request: NextRequest) {
         Authorization: `Bearer ${xaiApiKey}`,
       },
       body: JSON.stringify({
-        model: "grok-1.5-flash-latest",
+        model: "grok-3-mini",
         messages: apiMessages,
         max_tokens: 500, // Adjusted for potentially detailed responses
         temperature: 0.7,


### PR DESCRIPTION
Changes the xAI model used by the GlowBot backend API (`app/api/glowbot-chat/route.ts`) from `grok-1.5-flash-latest` to `grok-3-mini`.

This change is to resolve an API error where the previously specified model was not accessible by the configured API key/team.