### PR TITLE
fix: Correct input field disabling logic for GlowBot

### DIFF
--- a/components/dashboard/glowbot-chat.tsx
+++ b/components/dashboard/glowbot-chat.tsx
@@ -305,11 +305,11 @@ export function GlowBotChat() {
             placeholder="Ask GlowBot anything about skincare..." // Reverted placeholder
             onKeyPress={(e) => e.key === "Enter" && handleSendMessage()}
             className="flex-1"
-            disabled={!inputValue.trim() || isTyping} // Simplified disabled logic
+            disabled={isTyping} // Changed: Input is only disabled when isTyping
           />
           <Button
             onClick={handleSendMessage}
-            disabled={!inputValue.trim() || isTyping} // Simplified disabled logic
+            disabled={!inputValue.trim() || isTyping} // Unchanged: Button disabled if input is empty OR isTyping
             className="bg-gradient-to-r from-purple-500 to-pink-600 hover:from-purple-600 hover:to-pink-700"
           >
             <Send className="w-4 h-4" />


### PR DESCRIPTION
Updates `components/dashboard/glowbot-chat.tsx` to ensure the chat input field remains editable even when empty.

Previously, the `Input` component was disabled if `!inputValue.trim()` was true, preventing you from typing into an empty field. This change modifies the `disabled` prop for the `Input` component to only be `isTyping`.

The Send `Button` retains its original `disabled` logic of `!inputValue.trim() || isTyping`, so it is only active when there is text to send and I am not currently processing a message.

This resolves the issue where you were unable to type your own questions because the input field was incorrectly grayed out.