### PR TITLE
fix: Change GlowBot xAI model to grok-2

### DIFF
--- a/app/api/glowbot-chat/route.ts
+++ b/app/api/glowbot-chat/route.ts
@@ -75,7 +75,7 @@ export async function POST(request: NextRequest) {
         Authorization: `Bearer ${xaiApiKey}`,
       },
       body: JSON.stringify({
-        model: "grok-3-mini",
+        model: "grok-2",
         messages: apiMessages,
         max_tokens: 500, // Adjusted for potentially detailed responses
         temperature: 0.7,


### PR DESCRIPTION
Updates the xAI model used by the GlowBot backend API (`app/api/glowbot-chat/route.ts`) from `grok-3-mini` to `grok-2`.

This change is an attempt to resolve an API error where the `grok-3-mini` model returned an empty response due to token limits or other compatibility issues.