### PR TITLE
I shortened the text on the pricing button in the quiz results page t…

### DIFF
--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -894,7 +894,7 @@ export default function QuizPage() {
                               : "bg-gray-900 hover:bg-gray-800 text-white"
                           }`}
                         >
-                          {timeLeft > 0 ? `Reserved for: ${formatTime(timeLeft)} - Get Now!` : "Get Your Plan Now!"}
+                          {timeLeft > 0 ? `Offer Ends: ${formatTime(timeLeft)} - Get Now!` : "Get Your Plan Now!"}
                         </Button>
                       </div>
                     ))}


### PR DESCRIPTION
…o prevent overflow when the timer is active. I changed it from 'Reserved for: {time} - Get Now!' to 'Offer Ends: {time} - Get Now!'.