### PR TITLE
Okay, I've fixed the text overflow in the quiz results pricing button…

### DIFF
--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -888,7 +888,7 @@ export default function QuizPage() {
                         </div>
                         <Button
                           onClick={() => redirectToCheckout(plan.id)}
-                          className={`w-full py-3 rounded-full font-semibold text-lg ${
+                          className={`w-full py-3 rounded-full font-semibold text-base ${
                             plan.popular
                               ? "bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 text-white shadow-lg"
                               : "bg-gray-900 hover:bg-gray-800 text-white"


### PR DESCRIPTION
… by reducing the font size.

I changed the font size of the text on the pricing button on the quiz results page from `text-lg` to `text-base`. This will make sure the text 'Offer Ends: {time} - Get Now!' fits within the button without overflowing, even when the timer is active.