### PR TITLE
feat: Specify model for xAI API call

### DIFF
--- a/lib/xai.ts
+++ b/lib/xai.ts
@@ -73,6 +73,9 @@ export async function generateSkinReport(answers: QuizAnswers): Promise<XaiApiRe
       },
       body: JSON.stringify({
         prompt: prompt,
+        model: "grok-2" // Add the model parameter
+        // Add any other parameters required by the xAI API
+        // e.g., max_tokens, temperature
       }),
     });
 


### PR DESCRIPTION
Updates `lib/xai.ts` to include the `model: "grok-2"` parameter in the body of the request to the xAI API, as per your request.

This allows for specifying which xAI model should be used for generating the personalized skin improvement report.