### PR TITLE
fix: Update Supabase Edge Function name for sending emails

### DIFF
--- a/lib/email.ts
+++ b/lib/email.ts
@@ -16,7 +16,7 @@ interface ReportData {
  */
 export async function sendPersonalizedReportEmail(userEmail: string, reportData: ReportData): Promise<void> {
   // The name of your Supabase Edge Function
-  const edgeFunctionName = 'send-report-email';
+  const edgeFunctionName = 'resend-email'; // MODIFIED HERE
 
   console.log(`Attempting to send report to ${userEmail} via Supabase Edge Function '${edgeFunctionName}'...`);
 


### PR DESCRIPTION
Changes the `edgeFunctionName` in `lib/email.ts` from 'send-report-email' to 'resend-email'.

This aligns the client-side invocation with the correct name of the Supabase Edge Function responsible for handling email sending, as per your provided information about the function's endpoint URL.