### PR TITLE
Here's a change I've made:

### DIFF
--- a/supabase/functions/send-report-email/index.ts
+++ b/supabase/functions/send-report-email/index.ts
@@ -13,7 +13,7 @@ console.log("'resend-email' (or 'send-report-email') function booting up.");
 // Use the specific environment variable name provided by the user for the service role key.
 let supabaseAdmin: SupabaseClient | null = null;
 const supabaseUrl = Deno.env.get('SUPABASE_URL'); // Standard env var
-const serviceRoleKey = Deno.env.get('SERVICEROLE_KEY'); // User-specified new env var name
+const serviceRoleKey = Deno.env.get('SERVICE_ROLE'); // MODIFIED to SERVICE_ROLE
 
 if (supabaseUrl && serviceRoleKey) {
   supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
@@ -25,9 +25,9 @@ if (supabaseUrl && serviceRoleKey) {
       detectSessionInUrl: false
     }
   });
-  console.log("Supabase client initialized inside Edge Function using SERVICEROLE_KEY.");
+  console.log("Supabase client initialized inside Edge Function using SERVICE_ROLE."); // MODIFIED
 } else {
-  console.warn("Supabase client NOT initialized in Edge Function: SUPABASE_URL or SERVICEROLE_KEY missing.");
+  console.warn("Supabase client NOT initialized in Edge Function: SUPABASE_URL or SERVICE_ROLE missing."); // MODIFIED
 }
 
 


### PR DESCRIPTION
fix: Update env var name for Service Role Key in Edge Function template

I've modified the Supabase Edge Function template at `supabase/functions/send-report-email/index.ts`.

The code that initializes the Supabase client (if used within the function) now attempts to read the service role key from the environment variable `SERVICE_ROLE` (i.e., `Deno.env.get('SERVICE_ROLE')`), as per your latest feedback, changing it from the previously instructed `SERVICEROLE_KEY`. Corresponding console log messages have also been updated.

This commit updates the template file in the Next.js repository. You are responsible for applying this change to your actual deployed Supabase Edge Function and ensuring the `SERVICE_ROLE` environment variable is correctly set in your Supabase project for that function.