### PR TITLE
fix: Update Supabase Edge Function name to 'bright-api'

### DIFF
--- a/lib/email.ts
+++ b/lib/email.ts
@@ -16,7 +16,7 @@ interface ReportData {
  */
 export async function sendPersonalizedReportEmail(userEmail: string, reportData: ReportData): Promise<void> {
   // The name of your Supabase Edge Function
-  const edgeFunctionName = 'smooth-processor'; // MODIFIED HERE
+  const edgeFunctionName = 'bright-api'; // MODIFIED HERE
 
   console.log(`Attempting to send report to ${userEmail} via Supabase Edge Function '${edgeFunctionName}'...`);
 


### PR DESCRIPTION
Modifies `lib/email.ts` to change the `edgeFunctionName` from 'smooth-processor' to 'bright-api'.

This update reflects new information from you regarding the correct name of the Supabase Edge Function that should be invoked for the email report processing.