### PR TITLE
Fix: Use SERVICE_ROLE env var for Edge Function JWT

### DIFF
--- a/lib/email.ts
+++ b/lib/email.ts
@@ -12,10 +12,10 @@ export async function sendPersonalizedReportEmail(userEmail: string, reportData:
   const supabaseFunctionUrl = 'https://fkdnwzxainirielrpfzm.supabase.co/functions/v1/bright-api';
 
   // Retrieve the Service Role Key from environment variables
-  const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const supabaseServiceRoleKey = process.env.SERVICE_ROLE;
 
   if (!supabaseServiceRoleKey) {
-    console.error('[lib/email.ts] CRITICAL: SUPABASE_SERVICE_ROLE_KEY is not configured in the Next.js backend environment.');
+    console.error('[lib/email.ts] CRITICAL: SERVICE_ROLE is not configured in the Next.js backend environment.');
     throw new Error('Server configuration error: Missing Supabase service role key.');
     // This error will be caught by the calling API route and should return a 500.
   }


### PR DESCRIPTION
The email sending functionality was failing with a 401 Unauthorized error (Invalid JWT) when calling the Supabase Edge Function.

This commit updates `lib/email.ts` to use the `SERVICE_ROLE` environment variable, as specified by your issue requirements, to source the JWT for the Authorization header. Previously, it was using `SUPABASE_SERVICE_ROLE_KEY`.

The Authorization header format remains `Bearer <token>`, which is correct. This change ensures the Edge Function receives the token from the expected environment variable.