### PR TITLE
Debug: Temporarily enable full prompt logging

### DIFF
--- a/lib/xai.ts
+++ b/lib/xai.ts
@@ -128,7 +128,7 @@ The report must be structured as a JSON object with the following keys: "title",
   }
 
   console.log("Constructed xAI Prompt (first 200 chars):", prompt.substring(0, 200) + "..."); // Existing log
-  // console.log('[DEBUG xai.ts] Full prompt for xAI:', prompt); // Detailed debug log
+  console.log('[DEBUG xai.ts] Full prompt for xAI:', prompt); // Detailed debug log
 
   // Simulation logic (can be kept as is, or updated to return ReportStructure)
   if (process.env.NODE_ENV !== 'production' && XAI_API_KEY === 'mock-key-for-simulation-only') {


### PR DESCRIPTION
This commit re-enables logging of the complete, fully constructed prompt string before it is sent to the xAI service. This is intended for temporary debugging purposes to allow verification of quiz data insertion into the prompt.

The specific log line uncommented is:
`console.log('[DEBUG xai.ts] Full prompt for xAI:', prompt);`

This logging should be disabled again after debugging is complete.