### PR TITLE
feat: Add 'Name' field to quiz and personalize report email

### DIFF
--- a/app/api/generate-report/route.ts
+++ b/app/api/generate-report/route.ts
@@ -5,14 +5,15 @@ import { sendPersonalizedReportEmail } from '@/lib/email'; // Assuming @ is conf
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const { answers, email } = body; // Ensure 'answers' is the correct key from the frontend
+    const { answers, email, name } = body; // Ensure 'answers' is the correct key from the frontend
 
-    if (!answers || !email) {
-      return NextResponse.json({ error: 'Missing answers or email in request body' }, { status: 400 });
+    if (!answers || !email || !name) {
+      return NextResponse.json({ error: 'Missing answers, email, or name in request body' }, { status: 400 });
     }
 
     console.log('[API Route] Received quiz answers:', answers);
     console.log('[API Route] Received email:', email);
+    console.log('[API Route] Received name:', name);
 
     // 1. Generate the skin report using xAI
     let report;
@@ -30,11 +31,11 @@ export async function POST(request: Request) {
 
     // 2. Send the report to the user's email via Supabase Edge Function
     try {
-      console.log(`[API Route] Sending report to ${email}...`);
-      await sendPersonalizedReportEmail(email, report);
-      console.log(`[API Route] Report email process initiated for ${email}.`);
+      console.log(`[API Route] Sending report to ${name} at ${email}...`);
+      await sendPersonalizedReportEmail(name, email, report);
+      console.log(`[API Route] Report email process initiated for ${name} at ${email}.`);
     } catch (emailError: any) {
-      console.error(`[API Route] Error sending report email to ${email}:`, emailError);
+      console.error(`[API Route] Error sending report email to ${name} at ${email}:`, emailError);
       // Log the error, but might still return a partial success to the user
       // if the report was generated, or decide if this is a critical failure.
       // For now, let's assume if email fails, it's a significant issue for this flow.

--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -148,6 +148,7 @@ export default function QuizPage() {
   const [gameAnswer, setGameAnswer] = useState("");
   const [showEmailCapture, setShowEmailCapture] = useState(false);
   const [email, setEmail] = useState("");
+  const [name, setName] = useState(""); // Added name state
   const [showChallengeSetup, setShowChallengeSetup] = useState(false);
   const [challengeData, setChallengeData] = useState({
     title: "",
@@ -260,7 +261,7 @@ export default function QuizPage() {
   };
 
   const handleEmailSubmit = async () => { // Make the function async
-    if (!email) return;
+    if (!name || !email) return; // Added name check
     // setReportError(null); // Clear previous errors
     setIsGeneratingReport(true);
 
@@ -273,6 +274,7 @@ export default function QuizPage() {
         body: JSON.stringify({
           answers: answers, // The existing 'answers' state
           email: email,     // The existing 'email' state
+          name: name,       // Added name
         }),
       });
 
@@ -494,6 +496,14 @@ export default function QuizPage() {
                 <CardContent className="space-y-6">
                   <div className="space-y-4">
                     <Input
+                      type="text"
+                      placeholder="Enter your name"
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                      className="text-center text-lg p-4"
+                      required
+                    />
+                    <Input
                       type="email"
                       placeholder="Enter your email address"
                       value={email}
@@ -518,7 +528,7 @@ export default function QuizPage() {
                   </div>
                   <Button
                     onClick={handleEmailSubmit}
-                    disabled={!email || isGeneratingReport} // Disable if email is empty or report is generating
+                    disabled={!name || !email || isGeneratingReport} // Disable if name or email is empty or report is generating
                     className="w-full bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 text-white py-4 text-lg"
                   >
                     {isGeneratingReport ? 'Generating Your Report...' : 'Get My Personalized Report'}

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -7,7 +7,7 @@ interface ReportData {
   recommendations: string | string[] | null | undefined; // Make recommendations more flexible
 }
 
-export async function sendPersonalizedReportEmail(userEmail: string, reportData: ReportData): Promise<any> { // Return type changed to Promise<any>
+export async function sendPersonalizedReportEmail(name: string, userEmail: string, reportData: ReportData): Promise<any> { // Return type changed to Promise<any>
   // Use the specific Supabase Function URL provided by the user earlier
   const supabaseFunctionUrl = 'https://fkdnwzxainirielrpfzm.supabase.co/functions/v1/bright-api';
 
@@ -20,6 +20,7 @@ export async function sendPersonalizedReportEmail(userEmail: string, reportData:
     // This error will be caught by the calling API route and should return a 500.
   }
 
+  console.log(`[lib/email.ts] Received name for personalization: ${name}`);
   // Log the type and value of recommendations for debugging
   console.log('[lib/email.ts] Type of reportData.recommendations:', typeof reportData.recommendations, 'Value (JSON):', JSON.stringify(reportData.recommendations, null, 2));
 
@@ -56,12 +57,13 @@ export async function sendPersonalizedReportEmail(userEmail: string, reportData:
   // If recommendationsValue is null, not an object, or an object with no valid content, recommendationsHtml remains ''
 
   // Construct combined HTML content
-  const reportHtmlContent = `<h1>${reportData.title}</h1><div>${reportData.content}</div>${recommendationsHtml}`;
+  const greeting = `<h1>Hi ${name},</h1>`;
+  const reportHtmlContent = `${greeting}<h1>${reportData.title}</h1><div>${reportData.content}</div>${recommendationsHtml}`;
 
-  console.log(`[lib/email.ts] Attempting to send report to ${userEmail} via Edge Function: ${supabaseFunctionUrl}`);
+  console.log(`[lib/email.ts] Attempting to send report to ${name} <${userEmail}> via Edge Function: ${supabaseFunctionUrl}`);
   // Shorten log for HTML content if it's too long
   const reportExcerpt = reportHtmlContent.length > 300 ? reportHtmlContent.substring(0, 297) + "..." : reportHtmlContent;
-  console.log(`[lib/email.ts] Payload: email=${userEmail}, action=send-email, report HTML (excerpt/length)=${reportHtmlContent.length > 300 ? reportExcerpt + ` (length: ${reportHtmlContent.length})` : reportExcerpt}`);
+  console.log(`[lib/email.ts] Payload for ${name} <${userEmail}>: action=send-email, report HTML (excerpt/length)=${reportHtmlContent.length > 300 ? reportExcerpt + ` (length: ${reportHtmlContent.length})` : reportExcerpt}`);
 
   const response = await fetch(supabaseFunctionUrl, {
     method: 'POST',


### PR DESCRIPTION
This commit introduces a 'Name' field to the quiz's email capture screen and personalizes the report email with your name.

Changes include:
- Updated `app/quiz/page.tsx` to include a required 'Name' input field and send the name to the backend.
- Modified `app/api/generate-report/route.ts` to receive the 'name' and pass it to the email sending service.
- Updated `lib/email.ts` to prepend a personalized greeting "Hi [Name]," to the report email content. No changes were required for the Supabase Edge Function as it already handles dynamic HTML content for the email.