### PR TITLE
feat: Add blank Privacy Policy and Terms of Service pages

### DIFF
--- a/app/legal/privacy/page.tsx
+++ b/app/legal/privacy/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const PrivacyPolicyPage: React.FC = () => {
+  return (
+    <div>
+      <h1>Privacy Policy</h1>
+      <p>This is the privacy policy page.</p>
+    </div>
+  );
+};
+
+export default PrivacyPolicyPage;

--- a/app/legal/privacy_policy.md
+++ b/app/legal/privacy_policy.md
@@ -1,0 +1,3 @@
+# Privacy Policy
+
+This is a placeholder for the privacy policy.

--- a/app/legal/terms/page.tsx
+++ b/app/legal/terms/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const TermsOfServicePage: React.FC = () => {
+  return (
+    <div>
+      <h1>Terms of Service</h1>
+      <p>This is the terms of service page.</p>
+    </div>
+  );
+};
+
+export default TermsOfServicePage;

--- a/app/legal/terms_of_service.md
+++ b/app/legal/terms_of_service.md
@@ -1,0 +1,3 @@
+# Terms of Service
+
+This is a placeholder for the terms of service.

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -63,12 +63,12 @@ export function Footer() {
                 </Link>
               </li>
               <li>
-                <Link href="#" className="hover:text-white transition-colors">
+                <Link href="/legal/privacy" className="hover:text-white transition-colors">
                   Privacy Policy
                 </Link>
               </li>
               <li>
-                <Link href="#" className="hover:text-white transition-colors">
+                <Link href="/legal/terms" className="hover:text-white transition-colors">
                   Terms of Service
                 </Link>
               </li>


### PR DESCRIPTION
Creates new, initially blank, pages for the Privacy Policy and Terms of Service.

- Adds `app/legal/privacy/page.tsx` for the Privacy Policy.
- Adds `app/legal/terms/page.tsx` for the Terms of Service.
- Updates the links in the footer component (`components/footer.tsx`) to point to these new pages.