### PR TITLE
feat: Update Stripe weekly plan Price ID for test mode

### DIFF
--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -25,7 +25,7 @@ export { stripePromise }; // Export client-side stripe promise
 
 export const STRIPE_PLANS = {
   "1-week": {
-    priceId: "price_1RY9utHrpqSlBlhj6SdeRgKv", // Replace with actual Stripe price ID
+    priceId: "price_1RbHpzHF8iKj3yUNOdTxQY5q", // Replace with actual Stripe price ID
     amount: 693, // $6.93 in cents
     durationDays: 7,
   },


### PR DESCRIPTION
Switched the Price ID for the "1-week" plan in `lib/stripe.ts` to `price_1RbHpzHF8iKj3yUNOdTxQY5q` to facilitate testing with Stripe test mode credentials.

You will need to update the associated Stripe API keys (secret, webhook secret, publishable key) in your deployment environment to their respective test values.