### PR TITLE
Debug: Simplify get-user-subscription route for auth testing

### DIFF
--- a/app/api/get-user-subscription/route.ts
+++ b/app/api/get-user-subscription/route.ts
@@ -3,69 +3,29 @@ export const dynamic = 'force-dynamic';
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createAppRouteClient } from "@/lib/supabase";
-import { STRIPE_PLANS } from "@/lib/stripe";
+// Removed: import { STRIPE_PLANS } from "@/lib/stripe";
 
 export async function GET() {
-  const supabase = createAppRouteClient(cookies);
+  const cookieStore = cookies();
+  const supabase = createAppRouteClient(cookieStore);
+  console.log("Supabase client initialized in GET route.");
 
-  const { data: { user }, error: authError } = await supabase.auth.getUser();
-
-  if (authError || !user) {
-    console.error("Auth error:", authError);
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const { data: subscription, error: subscriptionError } = await supabase
-    .from("user_subscriptions")
-    .select("plan_id, purchase_date")
-    .eq("user_id", user.id)
-    .order("purchase_date", { ascending: false }) // Get the latest subscription
-    .limit(1)
-    .single(); // Expect a single record or null
-
-  if (subscriptionError) {
-    if (subscriptionError.code === 'PGRST116') { // PGRST116: "Searched for one object, but found 0 rows"
-        console.log(`No active subscription found for user ${user.id}`);
-        return NextResponse.json({ error: "No active subscription found" }, { status: 404 });
+  try {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError) {
+      console.error("Auth error during debugging:", authError);
+      return NextResponse.json({ error: "Auth error for debugging: " + authError.message }, { status: 401 });
     }
-    console.error(`Error fetching subscription for user ${user.id}:`, subscriptionError);
-    return NextResponse.json({ error: "Error fetching subscription" }, { status: 500 });
+    if (!user) {
+      console.log("No user found during debugging.");
+      return NextResponse.json({ error: "No user for debugging" }, { status: 404 });
+    }
+    console.log("User fetched successfully during debugging:", user.id);
+    return NextResponse.json({ message: "Debug: User fetched", userId: user.id });
+  } catch (e: any) {
+    console.error("Catch block error during debugging:", e);
+    return NextResponse.json({ error: "Catch block: " + e.message }, { status: 500 });
   }
 
-  if (!subscription) {
-    console.log(`No subscription found for user ${user.id}`);
-    return NextResponse.json({ error: "Subscription not found" }, { status: 404 });
-  }
-
-  const { plan_id, purchase_date } = subscription;
-
-  // Ensure plan_id is a valid key for STRIPE_PLANS
-  if (!(plan_id in STRIPE_PLANS)) {
-    console.error(`Invalid plan_id "${plan_id}" found for user ${user.id}. Not found in STRIPE_PLANS.`);
-    return NextResponse.json({ error: "Invalid plan ID in subscription record" }, { status: 500 });
-  }
-
-  // Type assertion for plan_id
-  const validPlanId = plan_id as keyof typeof STRIPE_PLANS;
-  const planDetails = STRIPE_PLANS[validPlanId];
-
-  if (!planDetails || typeof planDetails.durationDays !== 'number') {
-    console.error(`Plan details or durationDays missing for plan_id "${validPlanId}" from STRIPE_PLANS.`);
-    return NextResponse.json({ error: "Configuration error: Plan details are invalid" }, { status: 500 });
-  }
-
-  const purchaseDate = new Date(purchase_date);
-  const expirationDate = new Date(purchaseDate);
-  expirationDate.setDate(purchaseDate.getDate() + planDetails.durationDays);
-
-  // Construct a plan name. Could be more sophisticated if plans have display names.
-  const planName = `${validPlanId.replace('-', ' ')} Plan`; // e.g., "1 week Plan"
-
-  return NextResponse.json({
-    planId: validPlanId,
-    planName,
-    purchaseDate: purchaseDate.toISOString(),
-    expirationDate: expirationDate.toISOString(),
-    durationDays: planDetails.durationDays,
-  });
+  // All other logic related to fetching subscriptions, STRIPE_PLANS, etc. has been removed.
 }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -133,7 +133,7 @@ export const createAdminClient = () => {
 }
 
 // App Route Handler client (uses anon key, reads cookies)
-export const createAppRouteClient = (cookies: () => any) => {
+export const createAppRouteClient = (cookieStore: any) => { // Changed signature
   if (isV0Preview) {
     return createMockSupabaseClient()
   }
@@ -150,7 +150,7 @@ export const createAppRouteClient = (cookies: () => any) => {
     }
 
     console.log("lib/supabase: Initializing real App Route Supabase client. URL:", supabaseUrl, "Anon Key (first 5 chars):", supabaseAnonKey?.substring(0,5));
-    return createRouteHandlerClient({ cookies }, {
+    return createRouteHandlerClient(cookieStore, { // Changed call
       supabaseUrl,
       supabaseKey: supabaseAnonKey,
     })


### PR DESCRIPTION
This commit simplifies the `/api/get-user-subscription` route to isolate and test Supabase client initialization and `auth.getUser()` functionality.

Changes:
- Modified `lib/supabase.ts`'s `createAppRouteClient` to accept the cookie store instance (result of `cookies()`) directly, rather than the cookies function reference.
- Updated `app/api/get-user-subscription/route.ts` to pass the `cookieStore` to `createAppRouteClient`.
- Temporarily commented out the subscription fetching logic in `/api/get-user-subscription/route.ts`.
- Added detailed console logging in this route to trace the client initialization and `auth.getUser()` call.

This is intended to help diagnose the persistent `TypeError: t is not a function` error that occurs during Supabase client creation in the deployed environment. The route will now only attempt to fetch the user and return debugging information.