### PR TITLE
Debug: Add detailed logging for cookieStore in Supabase client init

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -138,6 +138,19 @@ export const createAppRouteClient = (cookieStore: any) => { // Changed signature
     return createMockSupabaseClient()
   }
 
+  // Detailed logging for cookieStore
+  console.log("Inspecting cookieStore in createAppRouteClient:");
+  console.log("typeof cookieStore:", typeof cookieStore);
+  console.log("cookieStore object:", cookieStore); // May be stringified
+  console.log("typeof cookieStore.get:", typeof cookieStore?.get);
+  console.log("typeof cookieStore.set:", typeof cookieStore?.set);
+  console.log("typeof cookieStore.remove:", typeof cookieStore?.remove);
+  try {
+    console.log("Attempting to call cookieStore.get('sb-test-cookie'):", cookieStore?.get('sb-test-cookie'));
+  } catch (e: any) {
+    console.error("Error calling cookieStore.get:", e.message);
+  }
+
   try {
     const { createRouteHandlerClient } = require("@supabase/ssr")
 


### PR DESCRIPTION
This commit adds extensive console logging within the `createAppRouteClient` function in `lib/supabase.ts`. The logging is specifically designed to inspect the `cookieStore` object (derived from `next/headers cookies()`) right before it is passed to `@supabase/ssr`'s `createRouteHandlerClient`.

Logs include:
- Type of `cookieStore`
- The `cookieStore` object itself (structure may vary in logs)
- Types of `get`, `set`, and `remove` methods on `cookieStore`
- Result (or error) of a test call to `cookieStore.get()`

This is intended to help diagnose the persistent
`TypeError: t is not a function` error encountered when initializing the Supabase client in the deployed Netlify environment. The goal is to understand if the `cookieStore` object is as expected or if it's altered or incomplete in that environment.