### PR TITLE
Debug: Add try-catch in cookieStoreForSupabase methods

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -154,17 +154,31 @@ export const createAppRouteClient = (cookieStore: any) => { // Changed signature
   // Define the sanitized cookie store for Supabase
   const cookieStoreForSupabase = {
     get(name: string) {
-      const cookie = cookieStore?.get(name);
-      console.log(`Cookie_get: ${name}`, cookie);
-      return cookie;
+      try {
+        const cookie = cookieStore?.get(name);
+        // Log the name and the value property of the cookie if it exists
+        console.log(`Cookie_get: ${name}, Value: `, cookie?.value);
+        return cookie;
+      } catch (e: any) {
+        console.error(`ERROR INSIDE cookieStoreForSupabase.get for ${name}:`, e.message);
+        return undefined; // Return undefined or re-throw as appropriate
+      }
     },
     set(name: string, value: string, options: any) {
-      console.log(`Cookie_set: ${name}`);
-      // No-op for now
+      try {
+        console.log(`Cookie_set: ${name}`);
+        // No-op for now
+      } catch (e: any) {
+        console.error(`ERROR INSIDE cookieStoreForSupabase.set for ${name}:`, e.message);
+      }
     },
     remove(name: string, options: any) {
-      console.log(`Cookie_remove: ${name}`);
-      // No-op for now
+      try {
+        console.log(`Cookie_remove: ${name}`);
+        // No-op for now
+      } catch (e: any) {
+        console.error(`ERROR INSIDE cookieStoreForSupabase.remove for ${name}:`, e.message);
+      }
     },
   };
 


### PR DESCRIPTION
This commit adds try-catch blocks within the get, set, and remove methods of the `cookieStoreForSupabase` shim in `lib/supabase.ts`.

The purpose is to:
- Catch and log any errors that might occur when these shimmed methods interact with the original `cookieStore` object (from `next/headers cookies()`).
- Help determine if the persistent `TypeError: t is not a function` originates from within these interactions or from an earlier stage within `@supabase/ssr`'s `createRouteHandlerClient` before these methods are even called.

The `Cookie_get` log was also updated to include the cookie's value.