### PR TITLE
Refine: Update patchedCookieStore with standard functions and logging

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -152,19 +152,21 @@ export const createAppRouteClient = (originalCookieStore: any) => { // Renamed p
   }
 
   const patchedCookieStore = {
-    get: (name: string) => {
-      // console.log(`PatchedCookieStore_get: ${name}`); // Optional log
+    get: function(name: string) {
+      console.log(`PatchedCookieStore_get call for: ${name}`);
+      // Assuming originalCookieStore.get is a function. We logged its type earlier.
       return originalCookieStore.get(name);
     },
-    set: (name: string, value: string, options: any) => {
-      // console.log(`PatchedCookieStore_set: ${name}`); // Optional log
+    set: function(name: string, value: string, options: any) {
+      console.log(`PatchedCookieStore_set call for: ${name}`);
+      // Assuming originalCookieStore.set is a function. We logged its type earlier.
       return originalCookieStore.set(name, value, options);
     },
-    remove: (name: string, options: any) => {
-      console.log(`PatchedCookieStore_remove: ${name}`); // Keep this log
+    remove: function(name: string, options: any) {
+      console.log(`PatchedCookieStore_remove call for: ${name}`);
       // Polyfill remove by setting an expired cookie on the original store
       originalCookieStore.set(name, '', { ...options, expires: new Date(0) });
-    },
+    }
   };
 
   try {


### PR DESCRIPTION
This commit refines the `patchedCookieStore` implementation within `createAppRouteClient` in `lib/supabase.ts`.

Changes:
- The `get`, `set`, and `remove` methods on `patchedCookieStore` are now defined using the `function` keyword to ensure they are standard function objects.
- Added specific console.log statements at the beginning of each of these patched methods (`PatchedCookieStore_get call for: ...`, etc.) to clearly indicate when and if `@supabase/ssr`'s `createRouteHandlerClient` attempts to call them.
- The `remove` method continues to use the polyfill (setting an expired cookie via `originalCookieStore.set`).
- This refined `patchedCookieStore` is passed to `createRouteHandlerClient`.

This change aims to provide the most compatible and debuggable cookie store interface to the Supabase library, helping to isolate the persistent `TypeError: t is not a function`.