### PR TITLE
Debug: Direct Supabase client init in API route

### DIFF
--- a/app/api/get-user-subscription/route.ts
+++ b/app/api/get-user-subscription/route.ts
@@ -2,30 +2,74 @@ export const dynamic = 'force-dynamic';
 
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
-import { createAppRouteClient } from "@/lib/supabase";
+import { createRouteHandlerClient } from '@supabase/ssr'; // Added
+// Removed: import { createAppRouteClient } from "@/lib/supabase";
 // Removed: import { STRIPE_PLANS } from "@/lib/stripe";
 
+// Define createPatchedCookieStoreForRoute locally
+const createPatchedCookieStoreForRoute = () => {
+  const store = cookies(); // from next/headers
+  return {
+    get: (name: string) => {
+      console.log(`DirectPatched_get: ${name}`);
+      return store.get(name);
+    },
+    set: (name: string, value: string, options: any) => {
+      console.log(`DirectPatched_set: ${name}`);
+      return store.set(name, value, options);
+    },
+    remove: (name: string, options: any) => {
+      console.log(`DirectPatched_remove: ${name}`);
+      store.set(name, '', { ...options, expires: new Date(0) });
+    },
+  };
+};
+
 export async function GET() {
-  const cookieStore = cookies();
-  const supabase = createAppRouteClient(cookieStore);
-  console.log("Supabase client initialized in GET route.");
+  const patchedCookieStore = createPatchedCookieStoreForRoute();
+
+  console.log("Direct init: typeof patchedCookieStore.get:", typeof patchedCookieStore.get);
+  console.log("Direct init: typeof patchedCookieStore.set:", typeof patchedCookieStore.set);
+  console.log("Direct init: typeof patchedCookieStore.remove:", typeof patchedCookieStore.remove);
+
+  let supabase: any; // Use 'any' for flexibility with mock assignment
 
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError) {
-      console.error("Auth error during debugging:", authError);
-      return NextResponse.json({ error: "Auth error for debugging: " + authError.message }, { status: 401 });
-    }
-    if (!user) {
-      console.log("No user found during debugging.");
-      return NextResponse.json({ error: "No user for debugging" }, { status: 404 });
-    }
-    console.log("User fetched successfully during debugging:", user.id);
-    return NextResponse.json({ message: "Debug: User fetched", userId: user.id });
+    supabase = createRouteHandlerClient(patchedCookieStore, {
+      supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    });
+    console.log("Supabase client REAL init attempt in route SUCCEEDED.");
   } catch (e: any) {
-    console.error("Catch block error during debugging:", e);
-    return NextResponse.json({ error: "Catch block: " + e.message }, { status: 500 });
+    console.error("ERROR during direct createRouteHandlerClient call in route:", e.message, e.stack);
+    // Fallback to a mock-like client
+    supabase = {
+      auth: {
+        getUser: async () => ({
+          data: { user: null },
+          error: { message: "Mock due to direct init failure: " + e.message }
+        })
+      }
+    };
+    console.log("Supabase client MOCK initialized in route due to error.");
   }
 
-  // All other logic related to fetching subscriptions, STRIPE_PLANS, etc. has been removed.
+  try {
+    console.log("Attempting supabase.auth.getUser() (direct init flow)...");
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError) {
+      console.error("Auth error (direct init flow):", authError.message);
+      return NextResponse.json({ error: "Auth error for debugging (direct init flow): " + authError.message }, { status: 401 });
+    }
+    if (!user) {
+      console.log("No user found (direct init flow).");
+      return NextResponse.json({ error: "No user for debugging (direct init flow)" }, { status: 404 });
+    }
+    console.log("User fetched successfully (direct init flow):", user.id);
+    return NextResponse.json({ message: "Debug: User fetched (direct init flow)", userId: user.id });
+  } catch (e: any) {
+    console.error("Catch block error during getUser (direct init flow):", e.message, e.stack);
+    return NextResponse.json({ error: "Catch block (direct init flow): " + e.message }, { status: 500 });
+  }
 }


### PR DESCRIPTION
This commit modifies `app/api/get-user-subscription/route.ts` to directly initialize the Supabase client using `@supabase/ssr`'s `createRouteHandlerClient`. This bypasses the `createAppRouteClient` abstraction from `lib/supabase.ts` for diagnostic purposes.

Changes:
- A local function `createPatchedCookieStoreForRoute` is defined in the API route file. It uses `cookies()` from `next/headers` and returns an object with `get`, `set`, and a polyfilled `remove` method. Each method includes logging.
- The `GET` handler in the API route now:
    - Creates an instance of this `patchedCookieStore`.
    - Logs the types of its `get`, `set`, and `remove` methods.
    - Calls `createRouteHandlerClient` directly with this store, wrapped in a try-catch.
    - Logs the success or failure of this direct initialization.
    - Continues with the simplified debug logic for `auth.getUser()`.

This isolates the client initialization to the route handler itself, helping to determine if the previous abstraction layer was contributing to the `TypeError: t is not a function` error or if the issue lies directly with `createRouteHandlerClient` and the cookie store in the Netlify environment.