### PR TITLE
I've been looking into the `@supabase/ssr` import in your API route.

### DIFF
--- a/app/api/get-user-subscription/route.ts
+++ b/app/api/get-user-subscription/route.ts
@@ -2,7 +2,7 @@ export const dynamic = 'force-dynamic';
 
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
-import { createRouteHandlerClient } from '@supabase/ssr'; // Added
+import * as supabaseSSR from '@supabase/ssr'; // Changed import
 // Removed: import { createAppRouteClient } from "@/lib/supabase";
 // Removed: import { STRIPE_PLANS } from "@/lib/stripe";
 
@@ -32,10 +32,15 @@ export async function GET() {
   console.log("Direct init: typeof patchedCookieStore.set:", typeof patchedCookieStore.set);
   console.log("Direct init: typeof patchedCookieStore.remove:", typeof patchedCookieStore.remove);
 
+  // Log supabaseSSR module content
+  console.log("Logging supabaseSSR module content H_E_R_E ---");
+  console.log("supabaseSSR module:", supabaseSSR);
+  console.log("typeof supabaseSSR.createRouteHandlerClient:", typeof supabaseSSR?.createRouteHandlerClient);
+
   let supabase: any; // Use 'any' for flexibility with mock assignment
 
   try {
-    supabase = createRouteHandlerClient(patchedCookieStore, {
+    supabase = supabaseSSR.createRouteHandlerClient(patchedCookieStore, { // Changed call
       supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
       supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     });


### PR DESCRIPTION
To help figure out the `(0 , u.createRouteHandlerClient) is not a function` error, I've made some changes to `app/api/get-user-subscription/route.ts`.

Here's what I did:
- I changed how `@supabase/ssr` is imported to use a namespace import: `import * as supabaseSSR from '@supabase/ssr';`
- I added some console logging to examine the entire `supabaseSSR` module and the `typeof supabaseSSR.createRouteHandlerClient`.
- I updated how the Supabase client is initialized to call `supabaseSSR.createRouteHandlerClient(...)`.

The goal here is to see if `createRouteHandlerClient` is being correctly exported and is usable as a function from the imported module when your code is deployed.